### PR TITLE
feat: improve Deployments

### DIFF
--- a/charts/sill/templates/deployment-api.yaml
+++ b/charts/sill/templates/deployment-api.yaml
@@ -6,13 +6,16 @@ metadata:
     {{- include "sill.api.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.api.replicaCount }}
+  {{- if .Values.api.updateStrategy }}
+  strategy: {{- toYaml .Values.api.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "sill.api.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "sill.api.selectorLabels" . | nindent 8 }}
     spec:
@@ -29,8 +32,12 @@ spec:
             {{- toYaml .Values.api.securityContext | nindent 12 }}
           image: "{{ .Values.api.image.name }}:{{ .Values.api.image.version }}"
           envFrom:
-            - configMapRef:
+            - secretRef:
+                {{- if .Values.existingSecret }}
+                name: {{ .Values.existingSecret }}
+                {{- else }}
                 name: {{ template "sill.fullname" . }}
+                {{- end }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           ports:
             - name: http
@@ -46,6 +53,12 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
+          volumeMounts:
+            - name: cache
+              mountPath: /node_modules/.cache/
+      volumes:
+        - name: cache
+          emptyDir: {}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/sill/templates/deployment-ui.yaml
+++ b/charts/sill/templates/deployment-ui.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "sill.web.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.web.replicaCount }}
+  {{- if .Values.web.updateStrategy }}
+  strategy: {{- toYaml .Values.web.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "sill.web.selectorLabels" . | nindent 6 }}

--- a/charts/sill/templates/secret.yaml
+++ b/charts/sill/templates/secret.yaml
@@ -1,5 +1,6 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ template "sill.fullname" . }}
   labels:
@@ -7,15 +8,17 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+type: Opaque
 data:
 {{- if .Values.api.env }}
 {{- range $key, $value := .Values.api.env }}
-  {{ $key }}: {{ $value | quote }}
+  {{ $key }}: {{ $value | b64enc | quote }}
 {{- end -}}
 {{- end -}}
 {{- if .Values.api.regions }}
-  regions: {{ .Values.api.regions | toJson | quote }}
+  regions: {{ .Values.api.regions | toJson | b64enc | quote }}
 {{- end}}
 {{- if .Values.api.catalogs }}
-  catalogs: {{ .Values.api.catalogs | toJson | quote }}
+  catalogs: {{ .Values.api.catalogs | toJson | b64enc | quote }}
+{{- end}}
 {{- end}}

--- a/charts/sill/values.yaml
+++ b/charts/sill/values.yaml
@@ -34,6 +34,8 @@ web:
     name: codegouvfr/sill-web
     version: latest
     pullPolicy: Always
+  #updateStrategy:
+  #  type: RollingUpdate
   podSecurityContext:
     {}
     # fsGroup: 2000
@@ -68,7 +70,7 @@ web:
 # env:
 #   API_URL: /api
 
-      
+
 
 api:
   name: api
@@ -77,6 +79,8 @@ api:
     name: codegouvfr/sill-api
     version: latest
     pullPolicy: Always
+  #updateStrategy:
+  #  type: RollingUpdate
   podSecurityContext:
     {}
     # fsGroup: 2000
@@ -130,3 +134,5 @@ api:
 #       "githubWebhookSecret": "xxxxxxxxxxxxxxx",
 #       "githubPersonalAccessToken": "ghp_xxxxxxxxxxxxxxxx",
 #     }
+
+# existingSecret: existingSecretName


### PR DESCRIPTION
use Secret instead of configMap
allow existing Secret (from vault)
allow Deployment Strategy
use emptyDir for caching sill-datas (useful for random user write rights)